### PR TITLE
Fix nbt_free(3) didn't free(3) tag_long_array buffer

### DIFF
--- a/nbt_treeops.c
+++ b/nbt_treeops.c
@@ -67,6 +67,9 @@ void nbt_free(nbt_node* tree)
     else if(tree->type == TAG_INT_ARRAY)
         free(tree->payload.tag_int_array.data);
 
+    else if(tree->type == TAG_LONG_ARRAY)
+        free(tree->payload.tag_long_array.data);
+
     else if(tree->type == TAG_STRING)
         free(tree->payload.tag_string);
 


### PR DESCRIPTION
This memory leak was found during the testings of my (NBTFS project)[https://sourceforge.net/projects/nbtfsutils/].